### PR TITLE
getAll only returns docs and not querySnapShot

### DIFF
--- a/__tests__/mock-firestore.test.js
+++ b/__tests__/mock-firestore.test.js
@@ -60,9 +60,7 @@ describe('Single records versus queries', () => {
     const secondRecord = db.collection('characters').doc('krusty');
 
     const records = await db.getAll(firstRecord, secondRecord);
-    expect(records.empty).toBe(false);
-    expect(records).toHaveProperty('docs', expect.any(Array))
-    expect(records.docs[0]).toHaveProperty('id', 'homer')
-    expect(records.docs[0].data()).toHaveProperty('name', 'Homer')
+    expect(records[0]).toHaveProperty('id', 'homer')
+    expect(records[0].data()).toHaveProperty('name', 'Homer')
   });
 });

--- a/mocks/firestore.js
+++ b/mocks/firestore.js
@@ -91,10 +91,7 @@ class FakeFirestore {
       .map(record => buildDocFromHash(record))
       .filter(record => !!record.id);
 
-    return Promise.resolve({
-      empty: records.length < 1,
-      docs: records
-    });
+    return Promise.resolve(records);
   }
 
   batch() {


### PR DESCRIPTION
# Description

`getAll` doesn't actually return a querySnapshot like I thought. It returns an array of docs.

## Related issues

## How to test
