### PR TITLE
Mock the unsubscribe callback returned by onSnapshot 

### DIFF
--- a/__tests__/full-setup-library-firestore.test.js
+++ b/__tests__/full-setup-library-firestore.test.js
@@ -22,6 +22,7 @@ describe.each([
     mockBatchCreate,
     mockSettings,
     mockOnSnapShot,
+    mockQueryOnSnapshotUnsubscribe,
     mockListCollections,
     mockTimestampNow,
     mockCreate,
@@ -378,7 +379,7 @@ describe.each([
 
         await flushPromises();
 
-        expect(unsubscribe).toBeInstanceOf(Function);
+        expect(unsubscribe).toBe(mockQueryOnSnapshotUnsubscribe);
         expect(mockWhere).toHaveBeenCalled();
         expect(mockOnSnapShot).toHaveBeenCalled();
       });

--- a/__tests__/full-setup.test.js
+++ b/__tests__/full-setup.test.js
@@ -34,6 +34,7 @@ describe.each`
     mockWithConverter,
     FakeFirestore,
     mockQueryOnSnapshot,
+    mockQueryOnSnapshotUnsubscribe,
     mockTimestampNow,
     mockRecursiveDelete,
   } = require('firestore-jest-mock/mocks/firestore');
@@ -411,7 +412,7 @@ describe.each`
 
       await flushPromises();
 
-      expect(unsubscribe).toBeInstanceOf(Function);
+      expect(unsubscribe).toBe(mockQueryOnSnapshotUnsubscribe);
       expect(mockWhere).toHaveBeenCalled();
       expect(mockOnSnapShot).not.toHaveBeenCalled();
       expect(mockQueryOnSnapshot).toHaveBeenCalled();

--- a/src/mocks/firestore.d.ts
+++ b/src/mocks/firestore.d.ts
@@ -160,6 +160,7 @@ export const mockOffset: jest.Mock;
 export const mockStartAfter: jest.Mock;
 export const mockStartAt: jest.Mock;
 export const mockQueryOnSnapshot: jest.Mock;
+export const mockQueryOnSnapshotUnsubscribe: jest.Mock;
 export const mockWithConverter: jest.Mock;
 
 // Mocks exported from Timestamp

--- a/src/mocks/query.d.ts
+++ b/src/mocks/query.d.ts
@@ -26,5 +26,6 @@ export const mocks: {
   mockStartAfter: jest.Mock,
   mockStartAt: jest.Mock,
   mockQueryOnSnapshot: jest.Mock,
+  mockQueryOnSnapshotUnsubscribe: jest.Mock,
   mockWithConverter: jest.Mock,
 };

--- a/src/mocks/query.js
+++ b/src/mocks/query.js
@@ -9,6 +9,7 @@ const mockOffset = jest.fn();
 const mockStartAfter = jest.fn();
 const mockStartAt = jest.fn();
 const mockQueryOnSnapshot = jest.fn();
+const mockQueryOnSnapshotUnsubscribe = jest.fn();
 const mockWithConverter = jest.fn();
 
 class Query {
@@ -140,8 +141,8 @@ class Query {
       }
     }
 
-    // Returns an unsubscribe function
-    return () => {};
+    // Returns an unsubscribe mock
+    return mockQueryOnSnapshotUnsubscribe;
   }
 }
 
@@ -157,6 +158,7 @@ module.exports = {
     mockStartAfter,
     mockStartAt,
     mockQueryOnSnapshot,
+    mockQueryOnSnapshotUnsubscribe,
     mockWithConverter,
   },
 };


### PR DESCRIPTION
# Description

Mock the unsubscribe callback returned by `onSnapshot` and export the mock as `mockQueryOnSnapshotUnsubscribe`.

A typical usage is to test whether the unsubscribe callback is called during your application's lifecycle.

## Usage

For example, here is a React component that subscribes on mount and unsubscribes on unmount:

```ts
const MyComponent = () => {
    useEffect(() => {
        const unsubscribe = firestore().collection('test').onSnapshot(() => {
            console.log('Got a snapshot');
        });

        return () => {
            unsubscribe();
        };
    }, []);

    return (...);
}
```

We want to test that the component unsubscribes on unmount. Thanks to `mockQueryOnSnapshotUnsubscribe` we can achieve this like this:

```ts
import { mockQueryOnSnapshotUnsubscribe } from 'firestore-jest-mock/mocks/firestore';

describe('MyComponent', () => {
    it('should unsubscribe on umount', () => {
        const { unmount } = render(<MyComponent />);
        expect(mockQueryOnSnapshotUnsubscribe).toHaveBeenCalledTimes(0);
        unmount();
        expect(mockQueryOnSnapshotUnsubscribe).toHaveBeenCalledTimes(1);
    });
});
```

## Related issues

Addresses #189 

## How to test

Unit tests `full-setup-library-firestore.test.js` and `full-setup.test.js` have been updated in order to assert that the unsubscribe callback returned by `onSnapshot` is `mockQueryOnSnapshotUnsubscribe`.