### PR TITLE
Reduce 'module not found' console logging

### DIFF
--- a/src/mocks/firebase.js
+++ b/src/mocks/firebase.js
@@ -39,17 +39,22 @@ const firebaseStub = (overrides, options = defaultOptions) => {
 };
 
 const mockFirebase = (overrides = {}, options = defaultOptions) => {
-  mockModuleIfFound('firebase', overrides, options);
-  mockModuleIfFound('firebase-admin', overrides, options);
+  const moduleFound = 
+    mockModuleIfFound('firebase', overrides, options) |
+    mockModuleIfFound('firebase-admin', overrides, options);
+  
+  if (!moduleFound) {
+    console.info(`Neither 'firebase' nor 'firebase-admin' modules found, mocking skipped.`);
+  }
 };
 
 function mockModuleIfFound(moduleName, overrides, options) {
   try {
     require.resolve(moduleName);
     jest.doMock(moduleName, () => firebaseStub(overrides, options));
+    return true;
   } catch (e) {
-    // eslint-disable-next-line no-console
-    console.info(`Module ${moduleName} not found, mocking skipped.`);
+    return false;
   }
 }
 


### PR DESCRIPTION
Many users will only have the ability to resolve module 'firebase' or 'firebase-admin' but not necessarily both. 

Impacted users see repeated logging of 'Module not found, mocking skipped' messages which can cause concern, and also pollute the logs of larger test suites with many such lines.

This change only logs to console in the more severe case where neither module can be found.

# Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

## How to test

<!-- Describe how to test your changes -->
