### PR TITLE
feat(query): support path select

### DIFF
--- a/__tests__/query.test.js
+++ b/__tests__/query.test.js
@@ -134,7 +134,7 @@ describe('Queries', () => {
       },
       currentUser: { uid: 'homer-user' },
     },
-    { simulateQueryFilters: true },
+    { simulateQueryFilters: true }
   );
 
   const firebase = require('firebase');
@@ -204,13 +204,36 @@ describe('Queries', () => {
     expect(res).toHaveProperty('size', 1);
     const cow = res.docs[0].data();
     expect(cow).toBeDefined();
-    expect(cow).toHaveProperty('id', 'cow');
     expect(cow).toHaveProperty('appearance', { color: 'brown' });
   });
 
-  test.todo('it can select and get nested values');
+  test('it can select and get nested values', async () => {
+    const res = await db
+      .collection('animals')
+      .where('id', '==', 'cow')
+      .select('appearance.color')
+      .get();
 
-  test.todo('iot can select many nested values');
+    expect(res).toHaveProperty('size', 1);
+    const appearance = res.docs[0].get('appearance');
+    expect(appearance).toEqual({ color: 'brown' });
+    const color = res.docs[0].get('appearance.color');
+    expect(color).toEqual('brown');
+  });
+
+  // TODO should add support
+  test.skip('it can select many nested values', async () => {
+    const res = await db
+      .collection('animals')
+      .where('id', '==', 'cow')
+      .select('appearance.color', 'appearance.size')
+      .get();
+
+    expect(res).toHaveProperty('size', 1);
+    const cow = res.docs[0].data();
+    expect(cow).toBeDefined();
+    expect(cow).toHaveProperty('appearance', {color: 'brown', size: 'large'});
+  });
 
   test('it can query date values for equality', async () => {
     const elephant = await db

--- a/__tests__/query.test.js
+++ b/__tests__/query.test.js
@@ -194,6 +194,24 @@ describe('Queries', () => {
     expect(cow).toHaveProperty('id', 'cow');
   });
 
+  test('it can select nested values', async () => {
+    const res = await db
+      .collection('animals')
+      .where('id', '==', 'cow')
+      .select('appearance.color')
+      .get();
+
+    expect(res).toHaveProperty('size', 1);
+    const cow = res.docs[0].data();
+    expect(cow).toBeDefined();
+    expect(cow).toHaveProperty('id', 'cow');
+    expect(cow).toHaveProperty('appearance', { color: 'brown' });
+  });
+
+  test.todo('it can select and get nested values');
+
+  test.todo('iot can select many nested values');
+
   test('it can query date values for equality', async () => {
     const elephant = await db
       .collection('animals')
@@ -443,10 +461,7 @@ describe('Queries', () => {
       // eslint-disable-next-line quotes
       "it performs '$comp' queries on number values ($count doc(s) where legCount $comp $value)",
       async ({ comp, value, count }) => {
-        const results = await db
-          .collection('animals')
-          .where('legCount', comp, value)
-          .get();
+        const results = await db.collection('animals').where('legCount', comp, value).get();
         expect(results.size).toBe(count);
       },
     );
@@ -475,10 +490,7 @@ describe('Queries', () => {
       // eslint-disable-next-line quotes
       "it performs '$comp' queries on number values that may be zero ($count doc(s) where foodCount $comp $value)",
       async ({ comp, value, count }) => {
-        const results = await db
-          .collection('animals')
-          .where('foodCount', comp, value)
-          .get();
+        const results = await db.collection('animals').where('foodCount', comp, value).get();
         expect(results.size).toBe(count);
       },
     );
@@ -505,10 +517,7 @@ describe('Queries', () => {
       // eslint-disable-next-line quotes
       "it performs '$comp' queries on string values ($count doc(s) where type $comp '$value')",
       async ({ comp, value, count }) => {
-        const results = await db
-          .collection('animals')
-          .where('type', comp, value)
-          .get();
+        const results = await db.collection('animals').where('type', comp, value).get();
         expect(results.size).toBe(count);
       },
     );
@@ -527,10 +536,7 @@ describe('Queries', () => {
       // eslint-disable-next-line quotes
       "it performs '$comp' queries on array values ($count doc(s) where food $comp '$value')",
       async ({ comp, value, count }) => {
-        const results = await db
-          .collection('animals')
-          .where('food', comp, value)
-          .get();
+        const results = await db.collection('animals').where('food', comp, value).get();
         expect(results.size).toBe(count);
       },
     );
@@ -550,10 +556,7 @@ describe('Queries', () => {
       // eslint-disable-next-line quotes
       "it performs '$comp' queries on array values that may be zero ($count doc(s) where foodEaten $comp '$value')",
       async ({ comp, value, count }) => {
-        const results = await db
-          .collection('animals')
-          .where('foodEaten', comp, value)
-          .get();
+        const results = await db.collection('animals').where('foodEaten', comp, value).get();
         expect(results.size).toBe(count);
       },
     );

--- a/__tests__/query.test.js
+++ b/__tests__/query.test.js
@@ -221,6 +221,18 @@ describe('Queries', () => {
     expect(color).toEqual('brown');
   });
 
+  test('it can handle missing nested values', async () => {
+    const res = await db
+      .collection('animals')
+      .where('id', '==', 'cow')
+      .select('size.height.shoulder')
+      .get();
+
+    expect(res).toHaveProperty('size', 1);
+    const data = res.docs[0].data();
+    expect(data).toHaveProperty('size', {});
+  });
+
   // TODO should add support
   test.skip('it can select many nested values', async () => {
     const res = await db

--- a/__tests__/query.test.js
+++ b/__tests__/query.test.js
@@ -233,8 +233,7 @@ describe('Queries', () => {
     expect(data).toHaveProperty('size', {});
   });
 
-  // TODO should add support
-  test.skip('it can select many nested values', async () => {
+  test('it can select many nested values', async () => {
     const res = await db
       .collection('animals')
       .where('id', '==', 'cow')

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "jest": "^26.6.3",
         "jest-watch-typeahead": "^0.3.1",
         "lint-staged": "^10.0.2",
+        "lodash": "^4.17.21",
         "prettier": "^3.1.1",
         "ts-jest": "^26.5.1",
         "typescript": "^4.9.5"
@@ -16244,7 +16245,8 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "jest": "^26.6.3",
     "jest-watch-typeahead": "^0.3.1",
     "lint-staged": "^10.0.2",
+    "lodash": "^4.17.21",
     "prettier": "^3.1.1",
     "ts-jest": "^26.5.1",
     "typescript": "^4.9.5"

--- a/src/mocks/helpers/buildDocFromHash.js
+++ b/src/mocks/helpers/buildDocFromHash.js
@@ -36,8 +36,6 @@ module.exports = function buildDocFromHash(hash = {}, id = 'abc123', selectField
             ...buildDocFromPath(copy, path)
           }
         }, {});
-
-        copy.id = this.id;
       }
 
       return copy;

--- a/src/mocks/helpers/buildDocFromHash.js
+++ b/src/mocks/helpers/buildDocFromHash.js
@@ -29,9 +29,15 @@ module.exports = function buildDocFromHash(hash = {}, id = 'abc123', selectField
       delete copy._updateTime;
 
       if (selectFields !== undefined) {
-        copy = Object.keys(copy)
-          .filter(key => key === 'id' || selectFields.includes(key))
-          .reduce((res, key) => ((res[key] = copy[key]), res), {});
+        copy = selectFields.reduce((acc, field) => {
+          const path = field.split('.');
+          return {
+            ...acc,
+            ...buildDocFromPath(copy, path)
+          }
+        }, {});
+
+        copy.id = this.id;
       }
 
       return copy;
@@ -56,3 +62,10 @@ module.exports = function buildDocFromHash(hash = {}, id = 'abc123', selectField
     },
   };
 };
+
+function buildDocFromPath(data, path) {
+  const [root, ...subPath] = path;
+  return {
+    [root]: subPath.length ? buildDocFromPath(data[root], subPath) : data[root]
+  };
+}

--- a/src/mocks/helpers/buildDocFromHash.js
+++ b/src/mocks/helpers/buildDocFromHash.js
@@ -1,4 +1,5 @@
 const timestamp = require('../timestamp');
+const {merge} = require('lodash');
 
 module.exports = function buildDocFromHash(hash = {}, id = 'abc123', selectFields = undefined) {
   const exists = !!hash || false;
@@ -31,10 +32,7 @@ module.exports = function buildDocFromHash(hash = {}, id = 'abc123', selectField
       if (selectFields !== undefined) {
         copy = selectFields.reduce((acc, field) => {
           const path = field.split('.');
-          return {
-            ...acc,
-            ...buildDocFromPath(copy, path)
-          }
+          return merge(acc, buildDocFromPath(copy, path));
         }, {});
       }
 

--- a/src/mocks/helpers/buildDocFromHash.js
+++ b/src/mocks/helpers/buildDocFromHash.js
@@ -62,8 +62,13 @@ module.exports = function buildDocFromHash(hash = {}, id = 'abc123', selectField
 };
 
 function buildDocFromPath(data, path) {
+  if (data === undefined || data === null) {
+    return {};
+  }
+
   const [root, ...subPath] = path;
+  const rootData = data[root];
   return {
-    [root]: subPath.length ? buildDocFromPath(data[root], subPath) : data[root]
+    [root]: subPath.length ? buildDocFromPath(rootData, subPath) : rootData
   };
 }

--- a/src/mocks/helpers/buildDocFromHash.js
+++ b/src/mocks/helpers/buildDocFromHash.js
@@ -1,5 +1,5 @@
 const timestamp = require('../timestamp');
-const {merge} = require('lodash');
+const merge = require('lodash/merge');
 
 module.exports = function buildDocFromHash(hash = {}, id = 'abc123', selectFields = undefined) {
   const exists = !!hash || false;


### PR DESCRIPTION
# Description
Instead of simply copying each selected key to result object, it breaks each select arg string by dots and recursively copies each key.

### Before
`.select('a.b')` => `{ 'a.b': ... }`

### After
`.select('a.b')` => `{a: {b: ... }}`

## Related issues
Fixes #199 

## Limitations
If two paths inside same property are selected (e.g. `"a.b"` and `"a.c"`) result will carry only the latest selected path.
See skipped [test case](https://github.com/sbatson5/firestore-jest-mock/compare/master...LorenzoSantoro94:path-select?expand=1#diff-25424277df3da0bf6a7d632eb2f4865a8d3afa22267e1405fbbd77cb25e8b214R225)
