### PR TITLE
fix: collection getter methods with subcollections path as strings

### DIFF
--- a/__tests__/mock-firestore.test.js
+++ b/__tests__/mock-firestore.test.js
@@ -53,6 +53,10 @@ describe('Queries', () => {
             },
           },
         ],
+        'subcollection/as/string': [
+          { id: '1', name: 'One' },
+          { id: '2', name: 'Two' }
+        ]
       },
       { simulateQueryFilters },
     );
@@ -267,6 +271,17 @@ describe('Queries', () => {
       expect(record).toHaveProperty('data');
       expect(record.data()).toHaveProperty('name', 'Violet');
     });
+
+    test('it can fetch records from subcollections with a string path', async () => {
+      // expect.assertions(8);
+      const subCollection = await db()
+        .collection('subcollection/as/string')
+
+      const allSubcollectionItems = await subCollection.get();
+      expect(allSubcollectionItems.docs.length).toBe(2);
+      expect(allSubcollectionItems.forEach).toBeTruthy();
+    });
+    
 
     test.each`
       simulateQueryFilters | expectedSize

--- a/src/mocks/firestore.js
+++ b/src/mocks/firestore.js
@@ -482,6 +482,11 @@ FakeFirestore.CollectionReference = class extends FakeFirestore.Query {
    * @returns {Object[]} An array of mocked document records.
    */
   _records() {
+    // Support subcollections as paths: "collection/documentId/subcollection"
+    if (this.firestore.database[this.path]) {
+      return this.firestore.database[this.path];
+    }
+    
     // Ignore leading slash
     const pathArray = this.path.replace(/^\/+/, '').split('/');
 


### PR DESCRIPTION
# Description

Collection getter methods (`.get()`, `.limit()`, etc) seem to return an empty set of items when collection is created with a string subcollections path. See example below.

This PR introduces a specific condition clause to support the described use case.

## Related issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

## How to test

```ts
import { FakeFirestore } from 'firestore-jest-mock/mocks/firestore'
import defaultOptions from 'firestore-jest-mock/mocks/helpers/defaultMockOptions'

const firestore = new FakeFirestore({
  'subcollection/as/string': [
    { id: '1', name: 'One' },
    { id: '2', name: 'Two' }
  ]
})

const collection = firestore.collection('subcollection/as/string')
const items = await collection.get()
// items.length === 2
```