### PR TITLE
docs: add modular API documentation and migration guide

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,138 @@
+# Migration Guide: Namespaced to Modular API
+
+This guide helps you migrate your test mocks from the Firebase v8 namespaced API to the v9+ modular API.
+
+## Overview
+
+The Firebase v9+ modular API uses free-standing functions instead of method chaining on class instances. This library provides separate mock setup functions for each API style:
+
+| API Style | Setup Function | Mock Import Path |
+|-----------|---------------|------------------|
+| Namespaced (v8) | `mockFirebase` | `firestore-jest-mock/mocks/firestore` |
+| Modular Firestore (v9+) | `mockModularFirestore` | `firestore-jest-mock/mocks/modular/firestore` |
+| Modular Auth (v9+) | `mockModularAuth` | `firestore-jest-mock/mocks/modular/auth` |
+| Admin modular (v10+) | `mockModularAdmin` | `firestore-jest-mock/mocks/modular/admin` |
+
+## Step-by-step Migration
+
+### 1. Update Mock Setup
+
+**Before (namespaced):**
+
+```js
+const { mockFirebase } = require('firestore-jest-mock');
+
+mockFirebase({
+  database: { users: [{ id: 'abc123', name: 'Homer' }] },
+});
+```
+
+**After (modular):**
+
+```js
+const { mockModularFirestore } = require('firestore-jest-mock');
+
+mockModularFirestore({
+  database: { users: [{ id: 'abc123', name: 'Homer' }] },
+});
+```
+
+### 2. Update Mock Imports for Assertions
+
+**Before (namespaced):**
+
+```js
+const { mockCollection, mockDoc, mockGet } = require('firestore-jest-mock/mocks/firestore');
+```
+
+**After (modular):**
+
+```js
+const {
+  mockGetDoc,
+  mockGetDocs,
+  mockModularCollection,
+  mockModularDoc,
+} = require('firestore-jest-mock/mocks/modular/firestore');
+```
+
+### 3. Update Firebase Imports in Your Code Under Test
+
+**Before (namespaced):**
+
+```js
+const firebase = require('firebase');
+firebase.initializeApp({ /* ... */ });
+const db = firebase.firestore();
+db.collection('users').doc('abc123').get();
+```
+
+**After (modular):**
+
+```js
+import { initializeApp } from 'firebase/app';
+import { getFirestore, collection, doc, getDoc } from 'firebase/firestore';
+
+initializeApp({ /* ... */ });
+const db = getFirestore();
+const docSnap = await getDoc(doc(db, 'users', 'abc123'));
+```
+
+### 4. Update Test Assertions
+
+**Before (namespaced):**
+
+```js
+expect(mockCollection).toHaveBeenCalledWith('users');
+expect(mockDoc).toHaveBeenCalledWith('abc123');
+expect(mockGet).toHaveBeenCalled();
+```
+
+**After (modular):**
+
+```js
+expect(mockModularDoc).toHaveBeenCalledWith(db, 'users/abc123');
+expect(mockGetDoc).toHaveBeenCalled();
+```
+
+## Mock Function Mapping
+
+### Firestore Operations
+
+| Namespaced Mock | Modular Mock | Modular Function |
+|----------------|-------------|-----------------|
+| `mockCollection` | `mockModularCollection` | `collection()` |
+| `mockCollectionGroup` | `mockModularCollectionGroup` | `collectionGroup()` |
+| `mockDoc` | `mockModularDoc` | `doc()` |
+| `mockGet` | `mockGetDoc` / `mockGetDocs` | `getDoc()` / `getDocs()` |
+| `mockAdd` | `mockAddDoc` | `addDoc()` |
+| `mockSet` | `mockSetDoc` | `setDoc()` |
+| `mockUpdate` | `mockUpdateDoc` | `updateDoc()` |
+| `mockDelete` | `mockDeleteDoc` | `deleteDoc()` |
+| `mockWhere` | `mockModularWhere` | `where()` |
+| `mockOrderBy` | `mockModularOrderBy` | `orderBy()` |
+| `mockLimit` | `mockModularLimit` | `limit()` |
+| `mockStartAt` | `mockModularStartAt` | `startAt()` |
+| `mockStartAfter` | `mockModularStartAfter` | `startAfter()` |
+| `mockOnSnapShot` | `mockModularOnSnapshot` | `onSnapshot()` |
+| `mockBatch` | `mockModularWriteBatch` | `writeBatch()` |
+| `mockRunTransaction` | `mockModularRunTransaction` | `runTransaction()` |
+
+### Auth Operations
+
+| Namespaced Mock | Modular Mock | Modular Function |
+|----------------|-------------|-----------------|
+| `mockCreateUserWithEmailAndPassword` | `mockModularCreateUserWithEmailAndPassword` | `createUserWithEmailAndPassword()` |
+| `mockSignInWithEmailAndPassword` | `mockModularSignInWithEmailAndPassword` | `signInWithEmailAndPassword()` |
+| `mockSignOut` | `mockModularSignOut` | `signOut()` |
+| `mockSendPasswordResetEmail` | `mockModularSendPasswordResetEmail` | `sendPasswordResetEmail()` |
+| N/A | `mockOnAuthStateChanged` | `onAuthStateChanged()` |
+| N/A | `mockConnectAuthEmulator` | `connectAuthEmulator()` |
+
+## Dual API Support
+
+Both modular and namespaced mocks share the same underlying `FakeFirestore` and `FakeAuth` classes. This means that when you use a modular function like `getDocs()`, both the modular mock (`mockGetDocs`) **and** the underlying namespaced mock (`mockGet`) are called. This allows incremental migration without breaking existing assertions.
+
+## Node.js Requirements
+
+This library now requires Node.js >= 18.

--- a/README.md
+++ b/README.md
@@ -15,29 +15,20 @@ Small, easy to grok pull requests are welcome, but please note that there is no 
 ## Table of Contents
 
 - [Mock Firestore](#mock-firestore)
-  - [⚠️ WARNING ⚠️](#️-warning-️)
-  - [Table of Contents](#table-of-contents)
   - [What's in the Box](#whats-in-the-box)
   - [Installation](#installation)
   - [Usage](#usage)
-    - [`mockFirebase`](#mockfirebase)
+    - [Modular API (Firebase v9+)](#modular-api-firebase-v9)
+    - [Namespaced API (Firebase v8 / compat)](#namespaced-api-firebase-v8--compat)
     - [`@google-cloud/firestore` compatibility](#google-cloudfirestore-compatibility)
     - [`@react-native-firebase/firestore` compatibility](#react-native-firebasefirestore-compatibility)
+    - [`firebase-admin` modular API (v10+)](#firebase-admin-modular-api-v10)
     - [Subcollections](#subcollections)
     - [What would you want to test?](#what-would-you-want-to-test)
     - [Don't forget to reset your mocks](#dont-forget-to-reset-your-mocks)
-      - [I wrote a where clause, but all the records were returned!](#i-wrote-a-where-clause-but-all-the-records-were-returned)
     - [Additional options](#additional-options)
-      - [`includeIdsInData`](#includeidsindata)
-      - [`mutable`](#mutable)
-      - [`simulateQueryFilters`](#simulatequeryfilters)
     - [Functions you can test](#functions-you-can-test)
-      - [Firestore](#firestore)
-      - [Firestore.Query](#firestorequery)
-      - [Firestore.FieldValue](#firestorefieldvalue)
-      - [Firestore.Timestamp](#firestoretimestamp)
-      - [Firestore.Transaction](#firestoretransaction)
-      - [Auth](#auth)
+  - [Migration Guide](#migration-guide)
   - [Contributing](#contributing)
   - [Code of Conduct](#code-of-conduct)
 
@@ -60,6 +51,96 @@ yarn add --dev firestore-jest-mock
 ```
 
 ## Usage
+
+### Modular API (Firebase v9+)
+
+If you use the Firebase v9+ modular API (`import { getFirestore, collection, getDocs } from 'firebase/firestore'`), use `mockModularFirestore`:
+
+```js
+const { mockModularFirestore } = require('firestore-jest-mock');
+const {
+  mockGetDoc,
+  mockGetDocs,
+  mockAddDoc,
+  mockSetDoc,
+  mockUpdateDoc,
+  mockDeleteDoc,
+  mockModularCollection,
+  mockModularDoc,
+  mockModularWhere,
+} = require('firestore-jest-mock/mocks/modular/firestore');
+
+describe('my tests', () => {
+  mockModularFirestore({
+    database: {
+      users: [
+        { id: 'abc123', name: 'Homer Simpson', state: 'IL' },
+        { id: 'abc456', name: 'Lisa Simpson', state: 'IL' },
+      ],
+    },
+  });
+
+  const {
+    getFirestore,
+    collection,
+    doc,
+    getDoc,
+    getDocs,
+    addDoc,
+    setDoc,
+    query,
+    where,
+  } = require('firebase/firestore');
+
+  test('get all users', async () => {
+    const db = getFirestore();
+    const usersRef = collection(db, 'users');
+    const snapshot = await getDocs(usersRef);
+
+    expect(snapshot.size).toBe(2);
+    expect(mockModularCollection).toHaveBeenCalledWith(db, 'users');
+    expect(mockGetDocs).toHaveBeenCalled();
+  });
+
+  test('get a single user', async () => {
+    const db = getFirestore();
+    const docRef = doc(db, 'users/abc123');
+    const docSnap = await getDoc(docRef);
+
+    expect(docSnap.exists).toBe(true);
+    expect(docSnap.data().name).toBe('Homer Simpson');
+  });
+
+  test('query with where', async () => {
+    const db = getFirestore();
+    const q = query(collection(db, 'users'), where('state', '==', 'IL'));
+    await getDocs(q);
+
+    expect(mockModularWhere).toHaveBeenCalledWith('state', '==', 'IL');
+  });
+});
+```
+
+For modular auth, use `mockModularAuth`:
+
+```js
+const { mockModularAuth } = require('firestore-jest-mock/mocks/modular/auth');
+const {
+  mockModularSignInWithEmailAndPassword,
+} = require('firestore-jest-mock/mocks/modular/auth');
+
+mockModularAuth({ currentUser: { uid: '123', email: 'test@test.com' } });
+
+const { getAuth, signInWithEmailAndPassword } = require('firebase/auth');
+
+test('sign in', async () => {
+  const auth = getAuth();
+  await signInWithEmailAndPassword(auth, 'test@test.com', 'password');
+  expect(mockModularSignInWithEmailAndPassword).toHaveBeenCalled();
+});
+```
+
+### Namespaced API (Firebase v8 / compat)
 
 ### `mockFirebase`
 
@@ -193,6 +274,42 @@ test('testing stuff', () => {
 
 _Note: Authentication with `@react-native-firebase/firestore` is not handled in the same way as with `firebase`.
 The `Auth` module is not available for `@react-native-firebase/firestore` compatibility._
+
+### `firebase-admin` modular API (v10+)
+
+If you use the firebase-admin v10+ modular entry points (`import { getFirestore } from 'firebase-admin/firestore'`), use `mockModularAdmin`:
+
+```js
+const { mockModularAdmin } = require('firestore-jest-mock/mocks/modular/admin');
+const {
+  mockAdminGetFirestore,
+  mockAdminGetAuth,
+} = require('firestore-jest-mock/mocks/modular/admin');
+
+mockModularAdmin({
+  database: {
+    users: [{ id: 'abc123', name: 'Homer Simpson' }],
+  },
+  currentUser: { uid: 'admin-user' },
+});
+
+const { initializeApp } = require('firebase-admin/app');
+const { getFirestore } = require('firebase-admin/firestore');
+const { getAuth } = require('firebase-admin/auth');
+
+test('admin firestore operations', async () => {
+  initializeApp();
+  const db = getFirestore();
+  const snapshot = await db.collection('users').get();
+  expect(snapshot.size).toBe(1);
+});
+
+test('admin auth operations', async () => {
+  const auth = getAuth();
+  const user = await auth.verifyIdToken('some-token');
+  expect(user).toBeDefined();
+});
+```
 
 ### Subcollections
 
@@ -465,6 +582,10 @@ If you need your tests to perform `where` queries on mock database data, you can
 | `mockVerifyIdToken`                  | Assert correct token is passed. Returns a promise                          | [verifyIdToken](https://firebase.google.com/docs/auth/admin/verify-id-tokens)                                                        |
 | `mockUseEmulator`                    | Assert correct emulator url is passed                                      | [useEmulator](https://firebase.google.com/docs/reference/js/v8/firebase.auth.Auth#useemulator)                                       |
 | `mockSignOut`                        | Assert sign out is called. Returns a promise                               | [signOut](https://firebase.google.com/docs/reference/js/auth.auth.md#authsignout)                                                    |
+
+## Migration Guide
+
+If you are migrating from the Firebase v8 namespaced API to the v9+ modular API, see [MIGRATION.md](MIGRATION.md) for a step-by-step guide on updating your test mocks.
 
 ## Contributing
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,5 @@ export { mockFirebase } from './mocks/firebase';
 export { mockGoogleCloudFirestore } from './mocks/googleCloudFirestore';
 export { mockReactNativeFirestore } from './mocks/reactNativeFirebaseFirestore';
 export { mockModularFirestore } from './mocks/modular/firestore';
+export { mockModularAuth } from './mocks/modular/auth';
+export { mockModularAdmin } from './mocks/modular/admin';


### PR DESCRIPTION
- Update README with modular Firestore, Auth, and Admin usage examples
- Add firebase-admin modular API section
- Create MIGRATION.md with step-by-step guide from namespaced to modular
- Include mock function mapping table for easy reference
- Export mockModularAuth and mockModularAdmin from main entry point
- Update table of contents